### PR TITLE
Implement display-summary endpoint enhancements to support Postman API Catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,8 @@ This project exposes a small HTTP API used to send text to the LED badge (or to 
 
 - POST `/display-summary`
     - Displays the demo summary text used by the project.
-    - Success: `200` with `{"status": "Summary displayed on LED"}`
+    - Without a Postman API key: `200` with `{"status": "Summary displayed on LED"}`
+    - With `X-Postman-API-Key` header (or `postmanApiKey` in the JSON body): fetches services from the Postman API Catalog and displays a compact health summary on the badge, returning catalog metadata in the response.
 
 Notes:
 - The API accepts only the `text` payload for display updates; other display settings (mode, speed, color, brightness) are controlled by the server and the real device. The mock enforces the same defaults used by the API: `mode=left`, `speed=4`, `color=red`.

--- a/api.py
+++ b/api.py
@@ -1,5 +1,6 @@
 from flask import Flask, request
 from lednamebadge import SimpleTextAndIcons, LedNameBadge
+from postman_catalog import PostmanCatalogError, fetch_catalog_summary
 from array import array
 
 import argparse
@@ -7,6 +8,8 @@ import threading
 import queue
 import importlib.util
 import os
+
+DEFAULT_SUMMARY = "Open LED Badge - Free, hackable, and fun! :star: :heart:"
 
 app = Flask(__name__)
 
@@ -65,9 +68,27 @@ def get_predefined_icons():
     return {'icons': icons}, 200
 
 
+def _get_postman_api_key(data):
+    return request.headers.get('X-Postman-API-Key') or (data or {}).get('postmanApiKey')
+
+
 @app.route('/display-summary', methods=['POST'])
 def display_summary():
-    summary = "Open LED Badge - Free, hackable, and fun! :star: :heart:"
+    data = request.get_json(silent=True) or {}
+    postman_api_key = _get_postman_api_key(data)
+    catalog_summary = None
+
+    if postman_api_key:
+        try:
+            catalog_summary = fetch_catalog_summary(
+                postman_api_key,
+                data.get('systemEnvironmentId'),
+            )
+            summary = catalog_summary['text']
+        except PostmanCatalogError as e:
+            return {'error': 'Failed to fetch API catalog', 'details': str(e)}, e.status_code
+    else:
+        summary = DEFAULT_SUMMARY
 
     try:
         creator = SimpleTextAndIcons()
@@ -78,7 +99,17 @@ def display_summary():
     global _API_COMMAND_QUEUE, _API_WRITE_HARDWARE
     _process_and_write(summary, command_queue=globals().get('_API_COMMAND_QUEUE'), write_hardware=globals().get('_API_WRITE_HARDWARE', True))
 
-    return {'status': 'Summary displayed on LED'}, 200
+    response = {'status': 'Summary displayed on LED'}
+    if catalog_summary is not None:
+        response.update({
+            'source': 'postman-api-catalog',
+            'text': summary,
+            'systemEnvironment': catalog_summary['systemEnvironment'],
+            'serviceCount': catalog_summary['serviceCount'],
+            'services': catalog_summary['services'],
+            'hasMore': catalog_summary['hasMore'],
+        })
+    return response, 200
 
 
 def _load_mock_console_module():

--- a/final-led-display-api.yaml
+++ b/final-led-display-api.yaml
@@ -392,20 +392,129 @@ paths:
                   status:
                     type: string
                     description: Status of the operation
-              example:
-                status: Summary displayed on LED
+                  source:
+                    type: string
+                    description: >-
+                      Present when a Postman API key was supplied. Indicates the
+                      summary was built from the Postman API catalog.
+                    enum:
+                      - postman-api-catalog
+                  text:
+                    type: string
+                    description: The text rendered on the LED badge
+                  systemEnvironment:
+                    type: object
+                    description: >-
+                      The API catalog system environment used to list services
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type: string
+                  serviceCount:
+                    type: integer
+                    description: Number of services returned for the summary
+                  hasMore:
+                    type: boolean
+                    description: >-
+                      True when additional catalog services exist beyond the
+                      fetched page
+                  services:
+                    type: array
+                    description: Catalog services included in the summary
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                        status:
+                          type: string
+                          enum:
+                            - healthy
+                            - warning
+                            - critical
+                            - inactive
+              examples:
+                defaultSummary:
+                  summary: Default summary without Postman API key
+                  value:
+                    status: Summary displayed on LED
+                catalogSummary:
+                  summary: Summary built from the Postman API catalog
+                  value:
+                    status: Summary displayed on LED
+                    source: postman-api-catalog
+                    text: 'Production - 3 svcs (2 ok, 1 warn) :star:'
+                    systemEnvironment:
+                      id: e34d6213-509d-4b61-94da-8b8c093cb925
+                      name: Production
+                    serviceCount: 3
+                    hasMore: false
+                    services:
+                      - id: 11111111-1111-1111-1111-111111111111
+                        name: payments-api
+                        status: healthy
+                      - id: 22222222-2222-2222-2222-222222222222
+                        name: billing-api
+                        status: warning
+                      - id: 33333333-3333-3333-3333-333333333333
+                        name: users-api
+                        status: healthy
+        '400':
+          description: Invalid display string format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Postman API key is invalid or unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: No API catalog system environments found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: A short description of the response
+        '502':
+          description: Postman API catalog request failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
       tags:
         - display-summary
       description: >-
-        Displays a predefined summary message on the LED badge. This endpoint
-        provides a quick way to show common status messages without constructing
-        custom text.
+        Displays a summary message on the LED badge.
 
 
-        Note: The API does not validate the type parameter and will return
+        Without a Postman API key, shows the built-in demo summary text. When
+        `X-Postman-API-Key` (or `postmanApiKey` in the body) is provided, the
+        endpoint fetches services from the [Postman API
+        Catalog](https://learning.postman.com/docs/api-catalog/overview) and
+        renders a compact health summary on the badge.
+
+
+        Note: The API does not validate the `type` parameter and will return
         success for any type value provided.
+      parameters:
+        - name: X-Postman-API-Key
+          in: header
+          required: false
+          description: >-
+            Optional Postman API key (`PMAK-...`). When set, the summary is
+            built from services in your API catalog instead of the default
+            message.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -420,6 +529,26 @@ paths:
                 customText:
                   type: string
                   description: Optional custom text to append to the summary
-            example:
-              type: welcome
-              customText: John
+                postmanApiKey:
+                  type: string
+                  description: >-
+                    Optional alternative to the `X-Postman-API-Key` header for
+                    supplying a Postman API key
+                systemEnvironmentId:
+                  type: string
+                  format: uuid
+                  description: >-
+                    Optional API catalog system environment ID. When omitted, the
+                    first production environment is used, otherwise the first
+                    environment with associations, otherwise the first available
+                    environment.
+            examples:
+              defaultSummary:
+                summary: Default demo summary
+                value:
+                  type: welcome
+                  customText: John
+              catalogSummary:
+                summary: API catalog summary
+                value:
+                  systemEnvironmentId: e34d6213-509d-4b61-94da-8b8c093cb925

--- a/postman/collections/Final LED Display API/display-summary/.resources/Display Summary from API Catalog.resources/examples/API catalog summary displayed successfully.example.yaml
+++ b/postman/collections/Final LED Display API/display-summary/.resources/Display Summary from API Catalog.resources/examples/API catalog summary displayed successfully.example.yaml
@@ -1,0 +1,57 @@
+$kind: http-example
+request:
+  url: "{{baseUrl}}/display-summary"
+  method: POST
+  headers:
+    - key: Content-Type
+      value: application/json
+    - key: Accept
+      value: application/json
+    - key: X-Postman-API-Key
+      value: <PMAK-your-api-key>
+  body:
+    type: json
+    content: |-
+      {
+        "systemEnvironmentId": "e34d6213-509d-4b61-94da-8b8c093cb925"
+      }
+response:
+  statusCode: 200
+  statusText: OK
+  headers:
+    Content-Type: application/json
+    Server: Werkzeug/3.1.5 Python/3.13.7
+    Date: Mon, 19 Jan 2026 12:25:00 GMT
+    Connection: close
+  body:
+    type: json
+    content: |-
+      {
+        "status": "Summary displayed on LED",
+        "source": "postman-api-catalog",
+        "text": "Production - 3 svcs (2 ok, 1 warn) :star:",
+        "systemEnvironment": {
+          "id": "e34d6213-509d-4b61-94da-8b8c093cb925",
+          "name": "Production"
+        },
+        "serviceCount": 3,
+        "hasMore": false,
+        "services": [
+          {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "name": "payments-api",
+            "status": "healthy"
+          },
+          {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "name": "billing-api",
+            "status": "warning"
+          },
+          {
+            "id": "33333333-3333-3333-3333-333333333333",
+            "name": "users-api",
+            "status": "healthy"
+          }
+        ]
+      }
+order: 1000

--- a/postman/collections/Final LED Display API/display-summary/Display Summary from API Catalog.request.yaml
+++ b/postman/collections/Final LED Display API/display-summary/Display Summary from API Catalog.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+name: Display Summary from API Catalog
+description: Displays a summary built from services in the Postman API Catalog. Requires a valid Postman API key in the `X-Postman-API-Key` header or `postmanApiKey` body field.
+url: "{{baseUrl}}/display-summary"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  X-Postman-API-Key: "{{vault:postmanApiKey}}"
+body:
+  type: json
+  content: |-
+    {
+      "systemEnvironmentId": "{{systemEnvironmentId}}"
+    }
+examples: ./.resources/Display Summary from API Catalog.resources/examples
+order: 2000

--- a/postman/collections/Final LED Display API/display-summary/Display Summary.request.yaml
+++ b/postman/collections/Final LED Display API/display-summary/Display Summary.request.yaml
@@ -1,7 +1,11 @@
 $kind: http-request
 description: >-
-  Displays a predefined summary message on the LED badge. This endpoint provides
-  a quick way to show common status messages without constructing custom text.
+  Displays a summary message on the LED badge.
+
+
+  Without a Postman API key, shows the built-in demo summary. Pass
+  `X-Postman-API-Key` (or `postmanApiKey` in the body) to fetch services from
+  the Postman API Catalog and display a compact health summary instead.
 
 
   Note: The API does not validate the type parameter and will return success for

--- a/postman/collections/Mock Answers LED Display API/display-summary/.resources/Display Summary from API Catalog.resources/examples/API catalog summary displayed successfully.example.yaml
+++ b/postman/collections/Mock Answers LED Display API/display-summary/.resources/Display Summary from API Catalog.resources/examples/API catalog summary displayed successfully.example.yaml
@@ -1,0 +1,57 @@
+$kind: http-example
+request:
+  url: "{{baseUrl}}/display-summary"
+  method: POST
+  headers:
+    - key: Content-Type
+      value: application/json
+    - key: Accept
+      value: application/json
+    - key: X-Postman-API-Key
+      value: <PMAK-your-api-key>
+  body:
+    type: json
+    content: |-
+      {
+        "systemEnvironmentId": "e34d6213-509d-4b61-94da-8b8c093cb925"
+      }
+response:
+  statusCode: 200
+  statusText: OK
+  headers:
+    Content-Type: application/json
+    Server: Werkzeug/3.1.5 Python/3.13.7
+    Date: Mon, 19 Jan 2026 12:25:00 GMT
+    Connection: close
+  body:
+    type: json
+    content: |-
+      {
+        "status": "Summary displayed on LED",
+        "source": "postman-api-catalog",
+        "text": "Production - 3 svcs (2 ok, 1 warn) :star:",
+        "systemEnvironment": {
+          "id": "e34d6213-509d-4b61-94da-8b8c093cb925",
+          "name": "Production"
+        },
+        "serviceCount": 3,
+        "hasMore": false,
+        "services": [
+          {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "name": "payments-api",
+            "status": "healthy"
+          },
+          {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "name": "billing-api",
+            "status": "warning"
+          },
+          {
+            "id": "33333333-3333-3333-3333-333333333333",
+            "name": "users-api",
+            "status": "healthy"
+          }
+        ]
+      }
+order: 1000

--- a/postman/collections/Mock Answers LED Display API/display-summary/Display Summary from API Catalog.request.yaml
+++ b/postman/collections/Mock Answers LED Display API/display-summary/Display Summary from API Catalog.request.yaml
@@ -1,0 +1,16 @@
+$kind: http-request
+description: Mock response for displaying a summary built from the Postman API Catalog.
+url: "{{baseUrl}}/display-summary"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  X-Postman-API-Key: "{{postmanApiKey}}"
+body:
+  type: json
+  content: |-
+    {
+      "systemEnvironmentId": "{{systemEnvironmentId}}"
+    }
+examples: ./.resources/Display Summary from API Catalog.resources/examples
+order: 2000

--- a/postman/collections/Mock Answers LED Display API/display-summary/Display Summary.request.yaml
+++ b/postman/collections/Mock Answers LED Display API/display-summary/Display Summary.request.yaml
@@ -1,6 +1,9 @@
 $kind: http-request
 description: |-
-  Displays a predefined summary message on the LED badge. This endpoint provides a quick way to show common status messages without constructing custom text.
+  Displays a summary message on the LED badge.
+
+  Without a Postman API key, shows the built-in demo summary. Pass
+  `X-Postman-API-Key` to fetch services from the Postman API Catalog instead.
 
   Note: The API does not validate the type parameter and will return success for any type value provided.
 url: "{{baseUrl}}/display-summary"

--- a/postman/environments/LED Display Localhost.environment.yaml
+++ b/postman/environments/LED Display Localhost.environment.yaml
@@ -1,6 +1,8 @@
 name: LED Display Localhost
 values:
   - key: baseUrl
-    value: http://localhost:5001
-    enabled: true
-color: null
+    value: 'http://localhost:5001'
+  - key: systemEnvironmentId
+    value: |
+      f54b15e9-9bf3-4514-a5b8-c76310d4c8bd
+color: 0

--- a/postman_catalog.py
+++ b/postman_catalog.py
@@ -1,0 +1,164 @@
+import json
+import os
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DEFAULT_POSTMAN_API_BASE_URL = 'https://api.getpostman.com'
+
+_STATUS_SHORT = {
+    'healthy': 'ok',
+    'warning': 'warn',
+    'critical': 'crit',
+    'inactive': 'off',
+}
+
+
+class PostmanCatalogError(Exception):
+    def __init__(self, message, status_code=502):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _ca_bundle_path():
+    for module_name in ('certifi', 'pip._vendor.certifi'):
+        try:
+            module = __import__(module_name, fromlist=['where'])
+            return module.where()
+        except (ImportError, AttributeError):
+            continue
+    return None
+
+
+def _ssl_context():
+    ca_bundle = _ca_bundle_path()
+    if ca_bundle:
+        return ssl.create_default_context(cafile=ca_bundle)
+    return ssl.create_default_context()
+
+
+def _api_base_url():
+    return os.environ.get('POSTMAN_API_BASE_URL', DEFAULT_POSTMAN_API_BASE_URL).rstrip('/')
+
+
+def _api_request(api_key, path, params=None):
+    query = f'?{urllib.parse.urlencode(params)}' if params else ''
+    url = f'{_api_base_url()}{path}{query}'
+    request = urllib.request.Request(
+        url,
+        headers={
+            'Accept': 'application/json',
+            'x-api-key': api_key,
+        },
+        method='GET',
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15, context=_ssl_context()) as response:
+            return json.loads(response.read().decode('utf-8'))
+    except urllib.error.HTTPError as exc:
+        details = exc.read().decode('utf-8', errors='replace')
+        raise PostmanCatalogError(
+            f'Postman API catalog request failed ({exc.code}): {details}',
+            status_code=exc.code if 400 <= exc.code < 500 else 502,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise PostmanCatalogError(f'Postman API catalog request failed: {exc.reason}') from exc
+
+
+def list_system_environments(api_key, limit=20):
+    payload = _api_request(api_key, '/api-catalog/system-environments', {'limit': limit})
+    return payload.get('data') or []
+
+
+def list_services(api_key, system_environment_id, limit=50):
+    payload = _api_request(
+        api_key,
+        '/api-catalog/services',
+        {
+            'systemEnvironmentId': system_environment_id,
+            'limit': limit,
+        },
+    )
+    return payload.get('data') or [], (payload.get('meta') or {}).get('nextCursor')
+
+
+def resolve_system_environment(api_key, preferred_id=None):
+    if preferred_id:
+        return {'id': preferred_id}
+
+    environments = list_system_environments(api_key)
+    if not environments:
+        raise PostmanCatalogError('No system environments found in API catalog', status_code=404)
+
+    for env in environments:
+        if env.get('isProduction'):
+            return env
+
+    for env in environments:
+        if env.get('associationCount', 0) > 0:
+            return env
+
+    return environments[0]
+
+
+def _sanitize_display_part(value):
+    if not value:
+        return value
+    return value.replace(':', '-')
+
+
+def build_display_text(services, environment_name=None, has_more=False):
+    label = _sanitize_display_part(environment_name) if environment_name else 'Catalog'
+    prefix = f'{label} - '
+
+    if not services:
+        return f'{prefix}0 svcs :star:'
+
+    counts = {}
+    for service in services:
+        status = service.get('status', 'unknown')
+        counts[status] = counts.get(status, 0) + 1
+
+    total = len(services)
+    status_parts = []
+    for status in ('healthy', 'warning', 'critical', 'inactive'):
+        count = counts.get(status)
+        if count:
+            short = _STATUS_SHORT.get(status, status)
+            status_parts.append(f'{count} {short}')
+
+    status_summary = ', '.join(status_parts) if status_parts else f'{total} svcs'
+    suffix = ' +more' if has_more else ''
+    return f'{prefix}{total} svcs ({status_summary}){suffix} :star:'
+
+
+def summarize_services(services):
+    return [
+        {
+            'id': service.get('id'),
+            'name': service.get('name'),
+            'status': service.get('status'),
+        }
+        for service in services
+    ]
+
+
+def fetch_catalog_summary(api_key, system_environment_id=None):
+    environment = resolve_system_environment(api_key, system_environment_id)
+    services, next_cursor = list_services(api_key, environment['id'])
+    text = build_display_text(
+        services,
+        environment_name=environment.get('name'),
+        has_more=bool(next_cursor),
+    )
+    return {
+        'text': text,
+        'systemEnvironment': {
+            'id': environment.get('id'),
+            'name': environment.get('name'),
+        },
+        'serviceCount': len(services),
+        'services': summarize_services(services),
+        'hasMore': bool(next_cursor),
+    }

--- a/prompts.md
+++ b/prompts.md
@@ -37,3 +37,125 @@ Can you provide a less fancy greeting with the current weather in SF to the LED 
 This API is not optimal for AI agents yet because its specification does not mention that you cannot use any special characters but the ones returned in the predefined icons call. Can you make this crystal clear in the documentation of the collection and its requests?
 
 Can you fetch the led display collection from postman (tagged led) and adopt this mcp server to work better based on its documentation? only change the mcp tool descriptions so that agents know how to use the api properly.
+
+## Postman plugin MCP — setup, search, and feature development
+
+Examples from a session that used the Postman plugin MCP server (`/setup`, `/search`, `/sync`, etc.) to explore internal APIs and ship a new feature end-to-end.
+
+### Discover the plugin and connect
+
+Show me how the Postman plugin works
+
+walk through setup
+
+### Search the Private API Network
+
+/search Postman API catalog API
+
+### Code a new feature (API + spec + collections)
+
+I like to extend the displaySummary endpoint in @api.py to actually retrieve the services listed in the Postman API catalog with a summary if a Postman API token is passed to it - otherwise it should have the same behavior as today. We probably also have to update the final spec and associated collections to make it work
+
+### Iterate when something breaks
+
+After calling `/display-summary` with a Postman API key, the API returned an SSL certificate error from the Postman catalog client. Fix the HTTPS calls so they work on macOS Python.
+
+After calling `/display-summary` with a Postman API key, the API returned `Invalid display string format` with details like `' 45 svcs (8 ok, 5 warn, 16 crit, 16 off) +more '`. The catalog summary text is failing LED validation — fix the summary format so it renders on the badge.
+
+### Tips for similar sessions
+
+- Start with `/setup` or “walk through setup” so MCP tools can reach your Postman workspace.
+- Use `/search <topic>` to find internal collections and specs before coding against them.
+- When extending the LED API, ask the agent to update `final-led-display-api.yaml`, `shared-components-api.yaml`, and the Postman collections under `postman/collections/` in the same change.
+- Pass optional integration config via request headers (e.g. `X-Postman-API-Key`) and document it in the OpenAPI spec and collection examples.
+- LED display text uses `:icon_name:` syntax — avoid bare colons in dynamic summary strings or they are parsed as invalid icons.
+
+## Postman plugin MCP — security audit
+
+Example from a session that used `/security` to audit the LED Display API against OWASP API Top 10, cross-checking the OpenAPI spec, backend code, and Postman collections.
+
+### Run a security audit
+
+/security
+
+### Follow up after findings
+
+Want me to implement the critical fixes (auth enforcement + error sanitization + bind address) in `api.py` and update the spec to match?
+
+### What the audit covered
+
+The agent reviewed `final-led-display-api.yaml`, `api.py`, `postman_catalog.py`, and the **Final LED Display API** collection. Findings were grouped by severity (CRITICAL / HIGH / MEDIUM / LOW) with OWASP API Top 10 mapping and concrete remediation snippets.
+
+Notable findings from this repo:
+
+- Spec declares `X-API-Key` auth globally, but `api.py` does not enforce it (CRITICAL).
+- Server defaults to `--host 0.0.0.0` with no auth — LAN-wide LED control (CRITICAL).
+- `/display-summary` accepts Postman API keys in the body and relays them to `api.getpostman.com` (HIGH).
+- Upstream Postman errors are returned verbatim in `details` (HIGH).
+- No rate limits or `maxLength` on display text; custom `:image.png:` paths can read local files (MEDIUM).
+
+### Tips for similar sessions
+
+- `/security` works on local specs alone — no Postman MCP connection required, but MCP helps audit collections and environments for leaked secrets.
+- Point the agent at both spec and implementation (`@api.py`) so it can catch spec vs. code mismatches (e.g. documented auth that is not enforced).
+- Ask for prioritized fixes and offer to implement CRITICAL items in the same follow-up prompt.
+- Re-run `/security` after fixes to get a before/after score comparison.
+
+## Postman plugin — agent readiness analysis
+
+Example from a session that asked whether the LED Display API is ready for AI agents. The agent scored the spec against the 8 pillars (48 checks): discover, understand, and self-heal.
+
+### Check if your API is agent-ready
+
+is my api agent ready?
+
+You can also ask:
+
+- Is my API agent-ready?
+- Scan my API for AI compatibility
+- What's wrong with my API for agents?
+
+### Follow up after the report
+
+Want me to apply the quick wins to `final-led-display-api.yaml` and `api.py`?
+
+### What the analysis covered
+
+The agent reviewed `final-led-display-api.yaml` (and implicitly `api.py` for spec vs. code alignment). Scoring uses weighted severity: **≥70% with zero critical failures** = agent-ready.
+
+Result for this repo: **~50/100 — not agent-ready** (2 critical blockers).
+
+**Strengths**
+
+- Rich `info.description` with icon list and character restrictions
+- `GET /predefined-icons` for discovering valid `:icon:` codes
+- Clear 400 example for unsupported Unicode emoji
+
+**Critical blockers**
+
+- No `operationId` on any endpoint (agents can't reliably select tools)
+- Incomplete error response schemas on some `4xx`/`5xx` responses
+
+**High-impact gaps**
+
+- No machine-readable `errorCode` field in errors
+- `text` not marked `required` on `/display-text`
+- No rate limit documentation
+- Spec requires `X-API-Key` but `api.py` does not enforce it
+- `/display-summary` documents `type` / `customText` but the server ignores them
+
+### Quick wins to reach agent-ready
+
+1. Add `operationId` to all endpoints
+2. Reference `ErrorResponse` on every error status
+3. Mark `text` as `required`; add `maxLength`
+4. Add `errorCode` enum to `ErrorResponse`
+5. Document agent workflow: call `listPredefinedIcons` before building display text
+6. Align auth in spec and `api.py`
+
+### Tips for similar sessions
+
+- Agent readiness is about **spec structure**, not just good prose — `operationId`, error schemas, and required fields matter most.
+- Cross-check `@api.py` when the spec claims auth or documents request fields the server ignores.
+- Combine with `/security` — spec/code mismatches hurt both security and agent reliability.
+- Re-ask after fixes to compare before/after scores.

--- a/shared-components-api.yaml
+++ b/shared-components-api.yaml
@@ -391,18 +391,126 @@ paths:
                   status:
                     type: string
                     description: Status of the operation
-              example:
-                status: Summary displayed on LED
+                  source:
+                    type: string
+                    description: >-
+                      Present when a Postman API key was supplied. Indicates the
+                      summary was built from the Postman API catalog.
+                    enum:
+                      - postman-api-catalog
+                  text:
+                    type: string
+                    description: The text rendered on the LED badge
+                  systemEnvironment:
+                    type: object
+                    description: >-
+                      The API catalog system environment used to list services
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type: string
+                  serviceCount:
+                    type: integer
+                    description: Number of services returned for the summary
+                  hasMore:
+                    type: boolean
+                    description: >-
+                      True when additional catalog services exist beyond the
+                      fetched page
+                  services:
+                    type: array
+                    description: Catalog services included in the summary
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                        status:
+                          type: string
+                          enum:
+                            - healthy
+                            - warning
+                            - critical
+                            - inactive
+              examples:
+                defaultSummary:
+                  summary: Default summary without Postman API key
+                  value:
+                    status: Summary displayed on LED
+                catalogSummary:
+                  summary: Summary built from the Postman API catalog
+                  value:
+                    status: Summary displayed on LED
+                    source: postman-api-catalog
+                    text: 'Production - 3 svcs (2 ok, 1 warn) :star:'
+                    systemEnvironment:
+                      id: e34d6213-509d-4b61-94da-8b8c093cb925
+                      name: Production
+                    serviceCount: 3
+                    hasMore: false
+                    services:
+                      - id: 11111111-1111-1111-1111-111111111111
+                        name: payments-api
+                        status: healthy
+                      - id: 22222222-2222-2222-2222-222222222222
+                        name: billing-api
+                        status: warning
+                      - id: 33333333-3333-3333-3333-333333333333
+                        name: users-api
+                        status: healthy
+        '400':
+          description: Invalid display string format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Postman API key is invalid or unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: No API catalog system environments found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Postman API catalog request failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
       tags:
         - display-summary
       description: >-
-        Displays a predefined summary message on the LED badge. This endpoint
-        provides a quick way to show common status messages without constructing
-        custom text.
+        Displays a summary message on the LED badge.
 
 
-        Note: The API does not validate the type parameter and will return
+        Without a Postman API key, shows the built-in demo summary text. When
+        `X-Postman-API-Key` (or `postmanApiKey` in the body) is provided, the
+        endpoint fetches services from the Postman API Catalog and renders a
+        compact health summary on the badge.
+
+
+        Note: The API does not validate the `type` parameter and will return
         success for any type value provided.
+      parameters:
+        - name: X-Postman-API-Key
+          in: header
+          required: false
+          description: >-
+            Optional Postman API key (`PMAK-...`). When set, the summary is
+            built from services in your API catalog instead of the default
+            message.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -417,6 +525,26 @@ paths:
                 customText:
                   type: string
                   description: Optional custom text to append to the summary
-            example:
-              type: welcome
-              customText: John
+                postmanApiKey:
+                  type: string
+                  description: >-
+                    Optional alternative to the `X-Postman-API-Key` header for
+                    supplying a Postman API key
+                systemEnvironmentId:
+                  type: string
+                  format: uuid
+                  description: >-
+                    Optional API catalog system environment ID. When omitted, the
+                    first production environment is used, otherwise the first
+                    environment with associations, otherwise the first available
+                    environment.
+            examples:
+              defaultSummary:
+                summary: Default demo summary
+                value:
+                  type: welcome
+                  customText: John
+              catalogSummary:
+                summary: API catalog summary
+                value:
+                  systemEnvironmentId: e34d6213-509d-4b61-94da-8b8c093cb925

--- a/tests/test_display_summary.py
+++ b/tests/test_display_summary.py
@@ -1,0 +1,73 @@
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+_mock_creator = MagicMock()
+_mock_lednamebadge = MagicMock()
+_mock_lednamebadge.SimpleTextAndIcons.return_value = _mock_creator
+sys.modules['lednamebadge'] = _mock_lednamebadge
+
+from api import DEFAULT_SUMMARY, app  # noqa: E402
+
+
+class TestDisplaySummary(TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+
+    def test_display_summary_without_postman_key_uses_default(self):
+        with patch('api._process_and_write') as write_mock:
+            response = self.client.post(
+                '/display-summary',
+                json={'type': 'welcome'},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body, {'status': 'Summary displayed on LED'})
+        write_mock.assert_called_once()
+        self.assertEqual(write_mock.call_args.args[0], DEFAULT_SUMMARY)
+
+    def test_display_summary_with_postman_key_uses_catalog(self):
+        catalog_summary = {
+            'text': 'Production - 2 svcs (2 ok) :star:',
+            'systemEnvironment': {'id': 'env-1', 'name': 'Production'},
+            'serviceCount': 2,
+            'services': [
+                {'id': 'svc-1', 'name': 'payments', 'status': 'healthy'},
+                {'id': 'svc-2', 'name': 'billing', 'status': 'healthy'},
+            ],
+            'hasMore': False,
+        }
+        with patch('api.fetch_catalog_summary', return_value=catalog_summary) as fetch_mock, patch(
+            'api._process_and_write',
+        ) as write_mock:
+            response = self.client.post(
+                '/display-summary',
+                headers={'X-Postman-API-Key': 'PMAK-test'},
+                json={'systemEnvironmentId': 'env-1'},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        fetch_mock.assert_called_once_with('PMAK-test', 'env-1')
+        body = response.get_json()
+        self.assertEqual(body['source'], 'postman-api-catalog')
+        self.assertEqual(body['serviceCount'], 2)
+        self.assertEqual(body['text'], catalog_summary['text'])
+        write_mock.assert_called_once_with(catalog_summary['text'], command_queue=None, write_hardware=True)
+
+    def test_display_summary_propagates_catalog_errors(self):
+        from postman_catalog import PostmanCatalogError
+
+        with patch(
+            'api.fetch_catalog_summary',
+            side_effect=PostmanCatalogError('Unauthorized', status_code=401),
+        ):
+            response = self.client.post(
+                '/display-summary',
+                headers={'X-Postman-API-Key': 'bad-key'},
+                json={},
+            )
+
+        self.assertEqual(response.status_code, 401)
+        body = response.get_json()
+        self.assertEqual(body['error'], 'Failed to fetch API catalog')

--- a/tests/test_postman_catalog.py
+++ b/tests/test_postman_catalog.py
@@ -1,0 +1,111 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from postman_catalog import (
+    PostmanCatalogError,
+    build_display_text,
+    fetch_catalog_summary,
+    resolve_system_environment,
+    summarize_services,
+)
+
+
+class TestPostmanCatalog(TestCase):
+    def test_build_display_text_with_status_breakdown(self):
+        services = [
+            {'name': 'payments', 'status': 'healthy'},
+            {'name': 'billing', 'status': 'warning'},
+            {'name': 'users', 'status': 'healthy'},
+        ]
+        text = build_display_text(services, environment_name='Production')
+        self.assertEqual(text, 'Production - 3 svcs (2 ok, 1 warn) :star:')
+
+    def test_build_display_text_empty_services(self):
+        text = build_display_text([], environment_name='Staging')
+        self.assertEqual(text, 'Staging - 0 svcs :star:')
+
+    def test_build_display_text_has_more_suffix(self):
+        services = [{'name': 'payments', 'status': 'healthy'}]
+        text = build_display_text(services, has_more=True)
+        self.assertEqual(text, 'Catalog - 1 svcs (1 ok) +more :star:')
+
+    def test_summarize_services(self):
+        services = [
+            {'id': '111', 'name': 'payments', 'status': 'healthy', 'traffic': {}},
+            {'id': '222', 'name': 'billing', 'status': 'warning', 'traffic': {}},
+        ]
+        self.assertEqual(
+            summarize_services(services),
+            [
+                {'id': '111', 'name': 'payments', 'status': 'healthy'},
+                {'id': '222', 'name': 'billing', 'status': 'warning'},
+            ],
+        )
+
+    def test_resolve_system_environment_prefers_production(self):
+        environments = [
+            {'id': 'a', 'name': 'Dev', 'isProduction': False, 'associationCount': 5},
+            {'id': 'b', 'name': 'Production', 'isProduction': True, 'associationCount': 0},
+        ]
+        with patch('postman_catalog.list_system_environments', return_value=environments):
+            env = resolve_system_environment('PMAK-test')
+        self.assertEqual(env['id'], 'b')
+
+    def test_resolve_system_environment_uses_associations_when_no_production(self):
+        environments = [
+            {'id': 'a', 'name': 'Dev', 'isProduction': False, 'associationCount': 0},
+            {'id': 'b', 'name': 'QA', 'isProduction': False, 'associationCount': 2},
+        ]
+        with patch('postman_catalog.list_system_environments', return_value=environments):
+            env = resolve_system_environment('PMAK-test')
+        self.assertEqual(env['id'], 'b')
+
+    def test_resolve_system_environment_raises_when_empty(self):
+        with patch('postman_catalog.list_system_environments', return_value=[]):
+            with self.assertRaises(PostmanCatalogError) as ctx:
+                resolve_system_environment('PMAK-test')
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_sanitize_display_part_replaces_colons(self):
+        from postman_catalog import _sanitize_display_part
+
+        self.assertEqual(_sanitize_display_part('env:prod'), 'env-prod')
+
+    def test_build_display_text_avoids_colon_icon_parsing(self):
+        counts = {'healthy': 8, 'warning': 5, 'critical': 16, 'inactive': 16}
+        services = []
+        for status, count in counts.items():
+            services.extend({'name': f'svc-{i}', 'status': status} for i in range(count))
+
+        text = build_display_text(services, environment_name='Production', has_more=True)
+        self.assertEqual(
+            text,
+            'Production - 45 svcs (8 ok, 5 warn, 16 crit, 16 off) +more :star:',
+        )
+        self.assertEqual(text.count(':'), 2)
+
+    def test_ssl_context_uses_ca_bundle_when_available(self):
+        with patch('postman_catalog._ca_bundle_path', return_value='/tmp/cacert.pem'), patch(
+            'postman_catalog.ssl.create_default_context',
+        ) as create_context:
+            from postman_catalog import _ssl_context
+
+            _ssl_context()
+        create_context.assert_called_once_with(cafile='/tmp/cacert.pem')
+
+    def test_fetch_catalog_summary(self):
+        environment = {'id': 'env-1', 'name': 'Production'}
+        services = [
+            {'id': 'svc-1', 'name': 'payments', 'status': 'healthy'},
+            {'id': 'svc-2', 'name': 'billing', 'status': 'critical'},
+        ]
+        with patch('postman_catalog.resolve_system_environment', return_value=environment), patch(
+            'postman_catalog.list_services',
+            return_value=(services, 'next-page'),
+        ):
+            result = fetch_catalog_summary('PMAK-test')
+
+        self.assertEqual(result['serviceCount'], 2)
+        self.assertTrue(result['hasMore'])
+        self.assertEqual(result['text'], 'Production - 2 svcs (1 ok, 1 crit) +more :star:')
+        self.assertEqual(result['systemEnvironment'], {'id': 'env-1', 'name': 'Production'})


### PR DESCRIPTION
The endpoint now fetches a health summary when a valid Postman API key is provided, returning detailed catalog metadata. Updated OpenAPI specifications and examples to reflect these changes, including error handling for API key issues and improved response structure.