### PR TITLE
Refactor API key handling in display-summary endpoint and update docu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ This project exposes a small HTTP API used to send text to the LED badge (or to 
 - POST `/display-summary`
     - Displays the demo summary text used by the project.
     - Without a Postman API key: `200` with `{"status": "Summary displayed on LED"}`
-    - With `X-Postman-API-Key` header (or `postmanApiKey` in the JSON body): fetches services from the Postman API Catalog and displays a compact health summary on the badge, returning catalog metadata in the response.
+    - With `X-API-Key` header (or `apiKey` in the JSON body): fetches services from the Postman API Catalog and displays a compact health summary on the badge, returning catalog metadata in the response.
 
 Notes:
 - The API accepts only the `text` payload for display updates; other display settings (mode, speed, color, brightness) are controlled by the server and the real device. The mock enforces the same defaults used by the API: `mode=left`, `speed=4`, `color=red`.

--- a/api.py
+++ b/api.py
@@ -68,20 +68,23 @@ def get_predefined_icons():
     return {'icons': icons}, 200
 
 
-def _get_postman_api_key(data):
-    return request.headers.get('X-Postman-API-Key') or (data or {}).get('postmanApiKey')
+def _get_api_key(data):
+    key = request.headers.get('X-API-Key') or (data or {}).get('apiKey')
+    if isinstance(key, str):
+        key = key.strip()
+    return key or None
 
 
 @app.route('/display-summary', methods=['POST'])
 def display_summary():
     data = request.get_json(silent=True) or {}
-    postman_api_key = _get_postman_api_key(data)
+    api_key = _get_api_key(data)
     catalog_summary = None
 
-    if postman_api_key:
+    if api_key:
         try:
             catalog_summary = fetch_catalog_summary(
-                postman_api_key,
+                api_key,
                 data.get('systemEnvironmentId'),
             )
             summary = catalog_summary['text']

--- a/final-led-display-api.yaml
+++ b/final-led-display-api.yaml
@@ -126,11 +126,18 @@ components:
       type: apiKey
       in: header
       name: X-API-Key
-      description: API key for authenticating requests to the LED Display API
+      description: >-
+        API key for requests to the LED Display API. On `/display-summary`, when
+        set, also used to fetch services from the Postman API Catalog; when
+        omitted or empty, the default demo summary is shown.
     ApiKeyAuth:
       type: apiKey
       in: header
       name: X-API-Key
+      description: >-
+        API key for requests to the LED Display API. On `/display-summary`, when
+        set, also used to fetch services from the Postman API Catalog; when
+        omitted or empty, the default demo summary is shown.
   responses:
     InternalServerError:
       description: Internal server error
@@ -482,39 +489,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: A short description of the response
-        '502':
-          description: Postman API catalog request failed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+  
       tags:
         - display-summary
       description: >-
         Displays a summary message on the LED badge.
 
 
-        Without a Postman API key, shows the built-in demo summary text. When
-        `X-Postman-API-Key` (or `postmanApiKey` in the body) is provided, the
-        endpoint fetches services from the [Postman API
+        Without an API key (`X-API-Key` header or `apiKey` in the body), shows
+        the built-in demo summary text. When a key is provided, the endpoint
+        fetches services from the [Postman API
         Catalog](https://learning.postman.com/docs/api-catalog/overview) and
         renders a compact health summary on the badge.
 
 
         Note: The API does not validate the `type` parameter and will return
         success for any type value provided.
-      parameters:
-        - name: X-Postman-API-Key
-          in: header
-          required: false
-          description: >-
-            Optional Postman API key (`PMAK-...`). When set, the summary is
-            built from services in your API catalog instead of the default
-            message.
-          schema:
-            type: string
       requestBody:
         content:
           application/json:
@@ -529,11 +519,11 @@ paths:
                 customText:
                   type: string
                   description: Optional custom text to append to the summary
-                postmanApiKey:
+                apiKey:
                   type: string
                   description: >-
-                    Optional alternative to the `X-Postman-API-Key` header for
-                    supplying a Postman API key
+                    Optional alternative to the `X-API-Key` header for supplying
+                    a Postman API key (`PMAK-...`) used to fetch the API catalog
                 systemEnvironmentId:
                   type: string
                   format: uuid

--- a/postman/collections/Final LED Display API/.resources/definition.yaml
+++ b/postman/collections/Final LED Display API/.resources/definition.yaml
@@ -1,4 +1,5 @@
 $kind: collection
+name: Final LED Display API
 description: |-
   # API for controlling LED name badge displays
 
@@ -94,9 +95,8 @@ description: |-
 variables:
   baseUrl: http://127.0.0.1:5001
 auth:
-  - id: f07e8a36-9f85-4646-9b55-49309fb8655b
-    type: apikey
-    name: apikey auth
-    credentials:
-      key: X-API-Key
-      in: header
+  type: apikey
+  credentials:
+    key: X-API-Key
+    in: header
+    value: "{{vault:postmanApiKey}}"

--- a/postman/collections/Final LED Display API/.resources/definition.yaml
+++ b/postman/collections/Final LED Display API/.resources/definition.yaml
@@ -99,4 +99,4 @@ auth:
   credentials:
     key: X-API-Key
     in: header
-    value: "{{vault:postmanApiKey}}"
+    value: "{{ledAPIKey}}"

--- a/postman/collections/Final LED Display API/display-summary/.resources/Display Summary from API Catalog.resources/examples/API catalog summary displayed successfully.example.yaml
+++ b/postman/collections/Final LED Display API/display-summary/.resources/Display Summary from API Catalog.resources/examples/API catalog summary displayed successfully.example.yaml
@@ -7,7 +7,7 @@ request:
       value: application/json
     - key: Accept
       value: application/json
-    - key: X-Postman-API-Key
+    - key: X-API-Key
       value: <PMAK-your-api-key>
   body:
     type: json

--- a/postman/collections/Final LED Display API/display-summary/Display Summary from API Catalog.request.yaml
+++ b/postman/collections/Final LED Display API/display-summary/Display Summary from API Catalog.request.yaml
@@ -1,12 +1,16 @@
 $kind: http-request
 name: Display Summary from API Catalog
-description: Displays a summary built from services in the Postman API Catalog. Requires a valid Postman API key in the `X-Postman-API-Key` header or `postmanApiKey` body field.
+description: Displays a summary built from services in the Postman API Catalog. Requires a valid Postman API key in the `X-API-Key` header or `apiKey` body field.
 url: "{{baseUrl}}/display-summary"
 method: POST
 headers:
   Content-Type: application/json
   Accept: application/json
-  X-Postman-API-Key: "{{vault:postmanApiKey}}"
+auth:
+  type: apikey
+  credentials:
+    value: "{{vault:postmanApiKey}}"
+    key: X-API-Key
 body:
   type: json
   content: |-

--- a/postman/collections/Final LED Display API/display-summary/Display Summary.request.yaml
+++ b/postman/collections/Final LED Display API/display-summary/Display Summary.request.yaml
@@ -3,9 +3,9 @@ description: >-
   Displays a summary message on the LED badge.
 
 
-  Without a Postman API key, shows the built-in demo summary. Pass
-  `X-Postman-API-Key` (or `postmanApiKey` in the body) to fetch services from
-  the Postman API Catalog and display a compact health summary instead.
+  Without an API key, shows the built-in demo summary. Pass `X-API-Key` (or
+  `apiKey` in the body) to fetch services from the Postman API Catalog and
+  display a compact health summary instead.
 
 
   Note: The API does not validate the type parameter and will return success for

--- a/postman/collections/Mock Answers LED Display API/display-summary/.resources/Display Summary from API Catalog.resources/examples/API catalog summary displayed successfully.example.yaml
+++ b/postman/collections/Mock Answers LED Display API/display-summary/.resources/Display Summary from API Catalog.resources/examples/API catalog summary displayed successfully.example.yaml
@@ -7,7 +7,7 @@ request:
       value: application/json
     - key: Accept
       value: application/json
-    - key: X-Postman-API-Key
+    - key: X-API-Key
       value: <PMAK-your-api-key>
   body:
     type: json

--- a/postman/collections/Mock Answers LED Display API/display-summary/Display Summary from API Catalog.request.yaml
+++ b/postman/collections/Mock Answers LED Display API/display-summary/Display Summary from API Catalog.request.yaml
@@ -5,7 +5,7 @@ method: POST
 headers:
   Content-Type: application/json
   Accept: application/json
-  X-Postman-API-Key: "{{postmanApiKey}}"
+  X-API-Key: "{{postmanApiKey}}"
 body:
   type: json
   content: |-

--- a/postman/collections/Mock Answers LED Display API/display-summary/Display Summary.request.yaml
+++ b/postman/collections/Mock Answers LED Display API/display-summary/Display Summary.request.yaml
@@ -3,7 +3,7 @@ description: |-
   Displays a summary message on the LED badge.
 
   Without a Postman API key, shows the built-in demo summary. Pass
-  `X-Postman-API-Key` to fetch services from the Postman API Catalog instead.
+  `X-API-Key` to fetch services from the Postman API Catalog instead.
 
   Note: The API does not validate the type parameter and will return success for any type value provided.
 url: "{{baseUrl}}/display-summary"

--- a/postman/environments/LED Display Localhost.environment.yaml
+++ b/postman/environments/LED Display Localhost.environment.yaml
@@ -5,4 +5,6 @@ values:
   - key: systemEnvironmentId
     value: |
       f54b15e9-9bf3-4514-a5b8-c76310d4c8bd
-color: 0
+  - key: ledAPIKey
+    value: '{{vault:postmanApiKey}}'
+color: 120

--- a/postman/environments/LED Display Mock Environment.environment.yaml
+++ b/postman/environments/LED Display Mock Environment.environment.yaml
@@ -1,6 +1,5 @@
 name: LED Display Mock Environment
 values:
   - key: baseUrl
-    value: https://16d7e73f-15b8-4fb0-87c4-fe02baff587a.mock.pstmn.io
-    enabled: true
-color: null
+    value: 'https://16d7e73f-15b8-4fb0-87c4-fe02baff587a.mock.pstmn.io'
+color: 60

--- a/postman/environments/LED Display Production.environment.yaml
+++ b/postman/environments/LED Display Production.environment.yaml
@@ -1,0 +1,10 @@
+name: LED Display Production
+values:
+  - key: baseUrl
+    value: 'http://localhost:5001'
+  - key: systemEnvironmentId
+    value: |
+      b352c3fe-8a70-484d-a81a-84c2d1d900b0
+  - key: ledAPIKey
+    value: '{{vault:postmanAPIKeyCatalog}}'
+color: 0

--- a/shared-components-api.yaml
+++ b/shared-components-api.yaml
@@ -125,7 +125,10 @@ components:
       type: apiKey
       in: header
       name: X-API-Key
-      description: API key for authenticating requests to the LED Display API
+      description: >-
+        API key for requests to the LED Display API. On `/display-summary`, when
+        set, also used to fetch services from the Postman API Catalog; when
+        omitted or empty, the default demo summary is shown.
   responses:
     InternalServerError:
       description: Internal server error
@@ -493,24 +496,14 @@ paths:
         Displays a summary message on the LED badge.
 
 
-        Without a Postman API key, shows the built-in demo summary text. When
-        `X-Postman-API-Key` (or `postmanApiKey` in the body) is provided, the
-        endpoint fetches services from the Postman API Catalog and renders a
-        compact health summary on the badge.
+        Without an API key (`X-API-Key` header or `apiKey` in the body), shows
+        the built-in demo summary text. When a key is provided, the endpoint
+        fetches services from the Postman API Catalog and renders a compact
+        health summary on the badge.
 
 
         Note: The API does not validate the `type` parameter and will return
         success for any type value provided.
-      parameters:
-        - name: X-Postman-API-Key
-          in: header
-          required: false
-          description: >-
-            Optional Postman API key (`PMAK-...`). When set, the summary is
-            built from services in your API catalog instead of the default
-            message.
-          schema:
-            type: string
       requestBody:
         content:
           application/json:
@@ -525,11 +518,11 @@ paths:
                 customText:
                   type: string
                   description: Optional custom text to append to the summary
-                postmanApiKey:
+                apiKey:
                   type: string
                   description: >-
-                    Optional alternative to the `X-Postman-API-Key` header for
-                    supplying a Postman API key
+                    Optional alternative to the `X-API-Key` header for supplying
+                    a Postman API key (`PMAK-...`) used to fetch the API catalog
                 systemEnvironmentId:
                   type: string
                   format: uuid

--- a/tests/test_display_summary.py
+++ b/tests/test_display_summary.py
@@ -27,7 +27,23 @@ class TestDisplaySummary(TestCase):
         write_mock.assert_called_once()
         self.assertEqual(write_mock.call_args.args[0], DEFAULT_SUMMARY)
 
-    def test_display_summary_with_postman_key_uses_catalog(self):
+    def test_display_summary_with_empty_api_key_uses_default(self):
+        with patch('api._process_and_write') as write_mock, patch(
+            'api.fetch_catalog_summary',
+        ) as fetch_mock:
+            response = self.client.post(
+                '/display-summary',
+                headers={'X-API-Key': '   '},
+                json={'apiKey': ''},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {'status': 'Summary displayed on LED'})
+        fetch_mock.assert_not_called()
+        write_mock.assert_called_once()
+        self.assertEqual(write_mock.call_args.args[0], DEFAULT_SUMMARY)
+
+    def test_display_summary_with_api_key_uses_catalog(self):
         catalog_summary = {
             'text': 'Production - 2 svcs (2 ok) :star:',
             'systemEnvironment': {'id': 'env-1', 'name': 'Production'},
@@ -43,7 +59,7 @@ class TestDisplaySummary(TestCase):
         ) as write_mock:
             response = self.client.post(
                 '/display-summary',
-                headers={'X-Postman-API-Key': 'PMAK-test'},
+                headers={'X-API-Key': 'PMAK-test'},
                 json={'systemEnvironmentId': 'env-1'},
             )
 
@@ -64,7 +80,7 @@ class TestDisplaySummary(TestCase):
         ):
             response = self.client.post(
                 '/display-summary',
-                headers={'X-Postman-API-Key': 'bad-key'},
+                headers={'X-API-Key': 'bad-key'},
                 json={},
             )
 


### PR DESCRIPTION
…mentation. Changed the function to retrieve API keys from headers and request body, replacing `X-Postman-API-Key` with `X-API-Key`. Updated OpenAPI specifications and README to reflect these changes, ensuring clarity on API key usage for fetching services from the Postman API Catalog.